### PR TITLE
add: closing html tag for cicd

### DIFF
--- a/README.md
+++ b/README.md
@@ -2677,6 +2677,8 @@ To handle this, I would start by reviewing deployment and application logs in st
 
 </details>
 
+</details>
+
 ## System Design
 
 <details>


### PR DESCRIPTION
## What happened?

We forgot to add a closing html tag at the end of cicd, so some of the sections were hidden in it as a result.